### PR TITLE
基本的にはインターフェース内でパラメータを使用しないように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It designed for server environments and can be used with scheduled tasks like cr
 
 ## Caution
 
-This environment is intended for local-only posts.  
+This tool is intended for local-only posts.  
 Since Fediverse platforms propagate delete requests across servers, excessive deletions may cause unnecessary load.  
 When using this tool on federated posts, set long intervals between requests and design your 
 code to minimise server load, even where no rate limits apply.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 A simple CLI tool to bulk-delete your posts on Misskey.  
 It designed for server environments and can be used with scheduled tasks like cron. 🚀
 
+## Caution
+
+This environment is intended for local-only posts.  
+Since Fediverse platforms propagate delete requests across servers, excessive deletions may cause unnecessary load.  
+When using this tool on federated posts, set long intervals between requests and design your 
+code to minimise server load, even where no rate limits apply.
+
 ---
 
 ## 🚀 Getting Started
@@ -26,3 +33,4 @@ It designed for server environments and can be used with scheduled tasks like cr
 This tool was originally built as a way for me to get more hands-on experience with Go.  
 If you spot anything that could be improved, feel free to open an issue or send a PR.  
 Suggestions and contributions are always welcome! 💥
+

--- a/clients.go
+++ b/clients.go
@@ -48,11 +48,7 @@ func (c *Client) Post(api string, args map[string]interface{}, result interface{
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		fmt.Printf("Warning: HTTP %d returned from %s\n", resp.StatusCode, api)
-		if result != nil {
-			_ = json.NewDecoder(resp.Body).Decode(result)
-		}
-		return nil
+		return fmt.Errorf("HTTP error: %d", resp.StatusCode)
 	}
 
 	if result != nil {

--- a/clients.go
+++ b/clients.go
@@ -48,7 +48,11 @@ func (c *Client) Post(api string, args map[string]interface{}, result interface{
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("HTTP error: %d", resp.StatusCode)
+		fmt.Printf("Warning: HTTP %d returned from %s\n", resp.StatusCode, api)
+		if result != nil {
+			_ = json.NewDecoder(resp.Body).Decode(result)
+		}
+		return nil
 	}
 
 	if result != nil {

--- a/note.go
+++ b/note.go
@@ -10,14 +10,14 @@ func (c *Client) DeleteNote(noteId string) error {
 
 func (c *Client) FetchNotes(userId, untilId string) ([]Note, error) {
 	args := map[string]interface{}{
-		"userId":           userId,
-		"limit":            100,
-		"withChannelNotes": true,
-		"withReplies":      true,
-		"localOnly":        true,
-		"isSensitive":      true,
-		"isHidden":         true,
-		"allowPartial":     true,
+		"userId": userId,
+		"limit":  100,
+		//"withChannelNotes": true,
+		//"withReplies":      true,
+		//"localOnly":        true,
+		//"isSensitive":      true,
+		//"isHidden":         true,
+		//"allowPartial":     true,
 	}
 	if untilId != "" {
 		args["untilId"] = untilId


### PR DESCRIPTION
APIのエンドポイントにパラメータが指定されてあるということは、
インターフェース内でそれを複数定義してしまうと条件指定になってしまうため、
AND制約で何も引っかからなくなっていた